### PR TITLE
Fork Kubernetes 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+This is the Igneous fork of Kubernetes. This repo contains features we've
+backported as well as customizations that are not (yet) upstream. We vendor
+this repo into our product codebase and in that repo link in our equivalent
+replacements for etcd, the apiserver, and other minor components. We provide
+no support for this repo.
+
+You can find the official project at [kubernetes.io].
+
 # Kubernetes
 
 [![Submit Queue Widget]][Submit Queue] [![GoDoc Widget]][GoDoc]

--- a/iggybot_config/jobs/build.yaml
+++ b/iggybot_config/jobs/build.yaml
@@ -1,0 +1,18 @@
+description: Build
+
+slavetypes:
+    - c3.4xlarge
+
+steps:
+    - Checkout
+
+    # build docker image
+    - ShellCommand:
+        command: [annotate-output, build/make-build-image.sh]
+        maxTime: 900
+        haltOnFailure: true
+
+    # run docker build for all platforms
+    - ShellCommand:
+        command: [annotate-output, build/run.sh, make, cross]
+        maxTime: 2400

--- a/iggybot_config/jobs/test.yaml
+++ b/iggybot_config/jobs/test.yaml
@@ -1,0 +1,23 @@
+description: Test
+
+slavetypes:
+    - c3.xlarge
+
+steps:
+    - Checkout
+
+    # build docker image
+    - ShellCommand:
+        command: [annotate-output, build/make-build-image.sh]
+        maxTime: 900
+        haltOnFailure: true
+
+    # run docker unit tests
+    - ShellCommand:
+        command: [annotate-output, build/run.sh, make, test]
+        maxTime: 900
+
+    # run docker cli tests
+    - ShellCommand:
+        command: [annotate-output, build/run.sh, make, test-cmd]
+        maxTime: 1200

--- a/iggybot_config/phases/build.yaml
+++ b/iggybot_config/phases/build.yaml
@@ -1,0 +1,8 @@
+description: Build Kubernetes
+
+pr: True
+quartz: 0
+
+jobs:
+    - build
+    - test


### PR DESCRIPTION
We need to backport features and make other minor tweeks to Kubernetes that aren't quickly upstreamable. The end goal should be to upstream everything that ends up in this repo, so lets keep this as a public fork. This PR adds a note to the README that this is a fork and adds config files for the Igneous build system.