### PR TITLE
Use glog

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -134,7 +134,7 @@ func (cgc *containerGC) removeOldestN(containers []containerGCInfo, toRemove int
 			}
 			message := "Container is in unknown state, try killing it before removal"
 			if err := cgc.manager.killContainer(nil, id, containers[i].name, message, nil); err != nil {
-				klog.Errorf("Failed to stop container %q: %v", containers[i].id, err)
+				glog.Errorf("Failed to stop container %q: %v", containers[i].id, err)
 				continue
 			}
 		}


### PR DESCRIPTION
Use glog instead of klog which has been replaced upstream.