### PR TITLE
Handle created state containers

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -140,7 +140,8 @@ func (m *kubeGenericRuntimeManager) getImageUser(image string) (*int64, string, 
 }
 
 // isInitContainerFailed returns true if container has exited and exitcode is not zero
-// or is in unknown state.
+// or is in unknown state or,
+// it has been in created state for over a minute.
 func isInitContainerFailed(status *kubecontainer.ContainerStatus) bool {
 	if status.State == kubecontainer.ContainerStateExited && status.ExitCode != 0 {
 		return true
@@ -148,6 +149,10 @@ func isInitContainerFailed(status *kubecontainer.ContainerStatus) bool {
 
 	if status.State == kubecontainer.ContainerStateUnknown {
 		return true
+	}
+
+	if status.State == kubecontainer.ContainerStateCreated {
+		return !kubecontainer.InCreatedStateGracePeriod(status)
 	}
 
 	return false

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -720,6 +720,11 @@ func findNextInitContainerToRun(pod *v1.Pod, podStatus *kubecontainer.PodStatus)
 			return nil, nil, false
 		}
 
+		// container is created within last one minute, return not done.
+		if status.State == kubecontainer.ContainerStateCreated && kubecontainer.InCreatedStateGracePeriod(status) {
+			return nil, nil, false
+		}
+
 		if status.State == kubecontainer.ContainerStateExited {
 			// all init containers successful
 			if i == (len(pod.Spec.InitContainers) - 1) {


### PR DESCRIPTION
If a container has been in created state for over a minute, then attempt to kill and restart it.

Any created containers currently are assumed dead and restarted even though it could transition to running state and result in two containers running.